### PR TITLE
Make program discovery more generic

### DIFF
--- a/Battmon/monitor/battery_monitor.py
+++ b/Battmon/monitor/battery_monitor.py
@@ -158,8 +158,9 @@ class Monitor(object):
     def __check_in_path(self, program_name, path=internal_config.EXTRA_PROGRAMS_PATH):
         try:
             for p in path:
-                if os.path.isfile(p + program_name):
-                    self.__current_program_path = (p + program_name)
+                regular_path = os.path.join(p, program_name)
+                if os.path.isfile(regular_path):
+                    self.__current_program_path = (regular_path)
                     return True
             else:
                 return False

--- a/Battmon/values/internal_config.py
+++ b/Battmon/values/internal_config.py
@@ -38,7 +38,7 @@ EPILOG = ('If you want change default screenlock command, edit DEFAULT_SCREEN_LO
 PROGRAM_PATH, n = os.path.split(os.path.dirname(os.path.realpath(__file__)))
 
 # path's for external things
-EXTRA_PROGRAMS_PATH = ['/usr/bin/',
+DEFAULT_EXTRA_PROGRAMS_PATH = ":".join(['/usr/bin/',
                        '/usr/local/bin/',
                        '/usr/local/sbin/',
                        '/bin/',
@@ -46,7 +46,8 @@ EXTRA_PROGRAMS_PATH = ['/usr/bin/',
                        '/usr/libexec/',
                        '/sbin/',
                        '/usr/share/sounds/',
-                       PROGRAM_PATH + "/bin/"]
+                       PROGRAM_PATH + "/bin/"])
+EXTRA_PROGRAMS_PATH = os.environ.get("PATH", DEFAULT_EXTRA_PROGRAMS_PATH).split(":")
 
 # default play command
 DEFAULT_PLAYER_COMMAND = ['paplay', 'play']


### PR DESCRIPTION
I had some issues with discovery of programs when they were installed in non-standard locations. I have updated the code to use a more generic technique of reading the PATH environment variable.

Thanks for the project